### PR TITLE
Set default_type to `model`

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -14,6 +14,7 @@ config:
   resource_types:
     - model
     - application
+  default_type: model
   url_root: https://raw.githubusercontent.com/ilastik/bioimage-io-models/master
 
 application:


### PR DESCRIPTION
When the partner icon is clicked, it will switch automatically to `models` tab.