### PR TITLE
disable check for leading ./

### DIFF
--- a/src/ilastik-packager.imjoy.html
+++ b/src/ilastik-packager.imjoy.html
@@ -141,7 +141,8 @@ async function downloadModel(rootUrl, spec, weightsFormat, showMessage, showProg
     }
   }
   // deprecate this after v0.4.0
-  if(spec.source && spec.source.startsWith('./')){
+  // TODO: Fix the leading ./ in the python library
+  if(spec.source){ // && spec.source.startsWith('./')
     const src = spec.source.split(':')[0] // e.g. ./mynetwork:UNet
     files.push(src)
     exportSpec.source = getFileName(src)


### PR DESCRIPTION
As @k-dominik pointed out there is some issue with the python implementation, we need to disable the leadings ./ check for the source field for now.