### PR TITLE
Display a test run button for the `UNet 2D Nuclei Broad` demo

### DIFF
--- a/src/ilastik-packager.imjoy.html
+++ b/src/ilastik-packager.imjoy.html
@@ -4,7 +4,7 @@
   "type": "window",
   "tags": [],
   "ui": "",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "api_version": "0.1.7",
   "description": "Export BioImage.IO model packages for ilastik from a model description file",
   "icon": "https://raw.githubusercontent.com/ilastik/bioimage-io-models/master/image/ilastik-fist-icon.png",
@@ -167,7 +167,7 @@ async function downloadModel(rootUrl, spec, weightsFormat, showMessage, showProg
   // after 0.4.0, rename source to architecture
   if(spec.weights[weightsFormat]){
     const wformat = spec.weights[weightsFormat];
-    if(wformat.architecture && wformat.architecture.startsWith('./')){
+    if(wformat.architecture && wformat.architecture.includes(':')){
       const src = wformat.architecture.split(':')[0] // e.g. ./mynetwork:UNet
       files.push(src)
       exportSpec.weights[weightsFormat].architecture = wformat.architecture
@@ -305,6 +305,17 @@ const app = new Vue({
         this.loading = false
       }
 
+    },
+    async testRun(){
+        try{
+            this.loading = true;
+            await api.showDialog({src: 'https://raw.githubusercontent.com/ilastik/bioimage-io-models/main/src/Ilastik-app.imjoy.html'});
+        } catch(e){
+            await api.alert(`Failed to run the model, error: ${e}`)
+        }
+        finally{
+            this.loading = false;
+        }
     }
   }
 })
@@ -351,16 +362,18 @@ api.export(new ImJoyPlugin())
       <ul>
           <li style="color: orange;" v-for="warning in warnings">{{warning}}</li>
       </ul>
-      <template v-for="weight in spec.config.weights_consumers" :key="weight">
-          <template v-for="consumer in weight.consumers">
-              <button style="margin:3px;" :key="consumer.name" v-if="consumer.name==='ilastik'" @click="download(weight.format)" class="btn btn-primary">Download ({{weight.name}})</button>
-          </template>
-      </template>
+     
       <p v-else-if="!spec">No model selected.</p>
       <p v-else-if="!spec.weights">No model weights available.</p>
       <div v-if="loading" class="loading loading-lg"></div>
       <progress v-if="progress" class="progress" :value="progress" max="100"></progress>
       <div class="d-block">{{status}}</div>
+       <template v-for="weight in spec.config.weights_consumers" :key="weight">
+          <template v-for="consumer in weight.consumers">
+              <button style="margin:3px;" :key="consumer.name" v-if="consumer.name==='ilastik'" @click="download(weight.format)" class="btn btn-primary">Download ({{weight.name}})</button>
+          </template>
+      </template>
+      <button style="margin:3px;" :disabled="modelInfo.name!=='UNet 2D Nuclei Broad' || loading" @click="testRun()" class="btn btn-primary">Test Run</button>
     </div>
   </div>
 </window>


### PR DESCRIPTION
<img width="930" alt="Screen Shot 2021-07-12 at 11 41 33 AM" src="https://user-images.githubusercontent.com/478667/125266468-241b2600-e306-11eb-904b-e251d4ec35bb.png">
