### PR TITLE
Move id to config._id

### DIFF
--- a/src/ilastik-app.imjoy.html
+++ b/src/ilastik-app.imjoy.html
@@ -123,6 +123,12 @@ async function downloadModel(rootUrl, spec, weightsFormat, showMessage, showProg
         return value;
     })
   );
+  // Move id to config for now
+  exportSpec.config = exportSpec.config || {}
+  if(exportSpec.id){
+    exportSpec.config._id = exportSpec.id
+    delete exportSpec.id
+  }
   await showMessage('Downloading files...')
   let files = []
   const weightsURL = spec.weights[weightsFormat].source


### PR DESCRIPTION
This PR moves the id key to config._id to solve the issue described here: https://github.com/bioimage-io/bioimage.io/issues/152