### PR TITLE
Add software label(i.e.: tag)

### DIFF
--- a/src/ilastik-app.imjoy.html
+++ b/src/ilastik-app.imjoy.html
@@ -8,6 +8,7 @@
   "api_version": "0.1.7",
   "description": "Export BioImage.IO model packages for ilastik from a model description file",
   "icon": "https://raw.githubusercontent.com/ilastik/bioimage-io-models/master/image/ilastik-fist-icon.png",
+  "labels": ["software"],
   "inputs": null,
   "outputs": null,
   "env": "",


### PR DESCRIPTION
Add a software tag so we can easily find all the consumer software in the application tab